### PR TITLE
fix: generate per-version release notes using cz changelog --start-rev

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,14 +12,17 @@ jobs:
     name: 'Publish GitHub Release'
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
       - name: Generate Release Notes
         run: |
           pip install -U commitizen
-          cz changelog
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^)
+          cz changelog --start-rev $PREV_TAG --file-name release_notes.md
       - name: Publish to Repository Releases
         uses: softprops/action-gh-release@v2
         with:
-          body_path: ${{ github.workspace }}/CHANGELOG.md
+          body_path: ${{ github.workspace }}/release_notes.md
 
   ruby-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Use `--start-rev` and `fetch-depth: 0` so each GitHub release shows only that version's changelog, not the full history.